### PR TITLE
Fix/eks private endpoint to unblock EKS Auto Mode to schedule EC2 nodes

### DIFF
--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -8,6 +8,7 @@ module "eks" {
   name = var.eks_config.cluster_name
   kubernetes_version = "1.33"
 
+  endpoint_private_access = true
   endpoint_public_access = true
   enable_cluster_creator_admin_permissions = true
 

--- a/terraform/env/dev.tfvars
+++ b/terraform/env/dev.tfvars
@@ -1,0 +1,2 @@
+env = "dev"
+aws_region = "ap-southeast-1"

--- a/terraform/env/prod.tfvars
+++ b/terraform/env/prod.tfvars
@@ -1,0 +1,2 @@
+env = "prod"
+aws_region = "ap-southeast-1"


### PR DESCRIPTION
Set endpoint_private_access to true in order for EKS Auto Mode to schedule nodes